### PR TITLE
Cygwin has fileno, so there's no need to use _fileno.

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -65,7 +65,7 @@
 /****************************
 *  OS-specific Includes
 *****************************/
-#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32) || defined(__CYGWIN__)
+#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32)
 #  include <io.h>       /* _isatty */
 #  ifdef __MINGW32__
    int _fileno(FILE *stream);   /* MINGW somehow forgets to include this prototype into <stdio.h> */

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -61,7 +61,7 @@
 /******************************
 *  OS-specific Includes
 ******************************/
-#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32) || defined(__CYGWIN__)
+#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32)
 #  include <fcntl.h>   /* _O_BINARY */
 #  include <io.h>      /* _setmode, _fileno, _get_osfhandle */
 #  define SET_BINARY_MODE(file) _setmode(_fileno(file), _O_BINARY)


### PR DESCRIPTION
I had to change _fileno() to fileno() to build lz4 on cygwin. Please review.