### PR TITLE
Fixed a decompression bug in lz4io.c

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -624,13 +624,14 @@ static unsigned long long decodeLZ4S(FILE* finput, FILE* foutput)
         readSize = fread(inBuff, 1, inBuffSize, finput);
         if (!readSize) break;   /* empty file or stream */
 
-        while (pos < readSize)
+        while (1)
         {
             /* Decode Input (at least partially) */
             size_t remaining = readSize - pos;
             size_t decodedBytes = outBuffSize;
             errorCode = LZ4F_decompress(ctx, outBuff, &decodedBytes, (char*)inBuff+pos, &remaining, NULL);
             if (LZ4F_isError(errorCode)) EXM_THROW(66, "Decompression error : %s", LZ4F_getErrorName(errorCode));
+            if (decodedBytes == 0 && remaining == 0) break;
             pos += remaining;
 
             if (decodedBytes)


### PR DESCRIPTION
- If an lz4 file does not have end mark, lz4c didn't decompress everything. But
  it said "Successfully decoded".
- Even if we consume all input data, we need to call LZ4F_decompress more times
  to pull all decoded data within the lib because dest buffer size might be
  smaller than decoded data.