### PR TITLE
Add LZ4 prefix to deprecation macros

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -285,21 +285,21 @@ int LZ4_decompress_fast_usingDict (const char* source, char* dest, int originalS
    it is generally possible to disable them,
    with -Wno-deprecated-declarations for gcc
    or _CRT_SECURE_NO_WARNINGS in Visual for example.
-   You can also define _DEPRECATE_WARNING_DEFBLOCK. */
-#ifndef _DEPRECATE_WARNING_DEFBLOCK
-#  define _DEPRECATE_WARNING_DEFBLOCK
+   You can also define LZ4_DEPRECATE_WARNING_DEFBLOCK. */
+#ifndef LZ4_DEPRECATE_WARNING_DEFBLOCK
+#  define LZ4_DEPRECATE_WARNING_DEFBLOCK
 #  define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #  if (GCC_VERSION >= 405) || defined(__clang__)
-#    define DEPRECATED(message) __attribute__((deprecated(message)))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
 #  elif (GCC_VERSION >= 301)
-#    define DEPRECATED(message) __attribute__((deprecated))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated))
 #  elif defined(_MSC_VER)
-#    define DEPRECATED(message) __declspec(deprecated(message))
+#    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
 #  else
-#    pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#    define DEPRECATED
+#    pragma message("WARNING: You need to implement LZ4_DEPRECATED for this compiler")
+#    define LZ4_DEPRECATED
 #  endif
-#endif // _DEPRECATE_WARNING_DEFBLOCK
+#endif // LZ4_DEPRECATE_WARNING_DEFBLOCK
 
 /* Obsolete compression functions */
 /* These functions are planned to generate warnings by r131 approximately */
@@ -321,14 +321,14 @@ int LZ4_compress_limitedOutput_continue  (LZ4_stream_t* LZ4_streamPtr, const cha
 /* int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize); */
 
 /* Obsolete streaming functions; use new streaming interface whenever possible */
-DEPRECATED("use LZ4_createStream() instead") void* LZ4_create (const char* inputBuffer);
-DEPRECATED("use LZ4_createStream() instead") int   LZ4_sizeofStreamState(void);
-DEPRECATED("use LZ4_resetStream() instead")  int   LZ4_resetStreamState(void* state, const char* inputBuffer);
-DEPRECATED("use LZ4_saveDict() instead")     char* LZ4_slideInputBuffer (void* state);
+LZ4_DEPRECATED("use LZ4_createStream() instead") void* LZ4_create (const char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_createStream() instead") int   LZ4_sizeofStreamState(void);
+LZ4_DEPRECATED("use LZ4_resetStream() instead")  int   LZ4_resetStreamState(void* state, const char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_saveDict() instead")     char* LZ4_slideInputBuffer (void* state);
 
 /* Obsolete streaming decoding functions */
-DEPRECATED("use LZ4_decompress_safe_usingDict() instead") int LZ4_decompress_safe_withPrefix64k (const char* source, char* dest, int compressedSize, int maxOutputSize);
-DEPRECATED("use LZ4_decompress_fast_usingDict() instead") int LZ4_decompress_fast_withPrefix64k (const char* source, char* dest, int originalSize);
+LZ4_DEPRECATED("use LZ4_decompress_safe_usingDict() instead") int LZ4_decompress_safe_withPrefix64k (const char* source, char* dest, int compressedSize, int maxOutputSize);
+LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") int LZ4_decompress_fast_withPrefix64k (const char* source, char* dest, int originalSize);
 
 
 #if defined (__cplusplus)

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -142,21 +142,21 @@ using LZ4_saveDictHC().
    it is generally possible to disable them,
    with -Wno-deprecated-declarations for gcc
    or _CRT_SECURE_NO_WARNINGS in Visual for example.
-   You can also define _DEPRECATE_WARNING_DEFBLOCK. */
-#ifndef _DEPRECATE_WARNING_DEFBLOCK
-#  define _DEPRECATE_WARNING_DEFBLOCK
+   You can also define LZ4_DEPRECATE_WARNING_DEFBLOCK. */
+#ifndef LZ4_DEPRECATE_WARNING_DEFBLOCK
+#  define LZ4_DEPRECATE_WARNING_DEFBLOCK
 #  define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #  if (GCC_VERSION >= 405) || defined(__clang__)
-#    define DEPRECATED(message) __attribute__((deprecated(message)))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
 #  elif (GCC_VERSION >= 301)
-#    define DEPRECATED(message) __attribute__((deprecated))
+#    define LZ4_DEPRECATED(message) __attribute__((deprecated))
 #  elif defined(_MSC_VER)
-#    define DEPRECATED(message) __declspec(deprecated(message))
+#    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
 #  else
-#    pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#    define DEPRECATED
+#    pragma message("WARNING: You need to implement LZ4_DEPRECATED for this compiler")
+#    define LZ4_DEPRECATED
 #  endif
-#endif // _DEPRECATE_WARNING_DEFBLOCK
+#endif // LZ4_DEPRECATE_WARNING_DEFBLOCK
 
 /* compression functions */
 /* these functions are planned to trigger warning messages by r131 approximately */
@@ -172,13 +172,13 @@ int LZ4_compressHC_continue               (LZ4_streamHC_t* LZ4_streamHCPtr, cons
 int LZ4_compressHC_limitedOutput_continue (LZ4_streamHC_t* LZ4_streamHCPtr, const char* source, char* dest, int inputSize, int maxOutputSize);
 
 /* Streaming functions following the older model; should no longer be used */
-DEPRECATED("use LZ4_createStreamHC() instead") void* LZ4_createHC (const char* inputBuffer);
-DEPRECATED("use LZ4_saveDictHC() instead")     char* LZ4_slideInputBufferHC (void* LZ4HC_Data);
-DEPRECATED("use LZ4_freeStreamHC() instead")   int   LZ4_freeHC (void* LZ4HC_Data);
-DEPRECATED("use LZ4_compressHC_safe_continue() instead") int   LZ4_compressHC2_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int compressionLevel);
-DEPRECATED("use LZ4_compressHC_safe_continue() instead") int   LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
-DEPRECATED("use LZ4_createStreamHC() instead") int   LZ4_sizeofStreamStateHC(void);
-DEPRECATED("use LZ4_resetStreamHC() instead")  int   LZ4_resetStreamStateHC(void* state, const char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_createStreamHC() instead") void* LZ4_createHC (const char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_saveDictHC() instead")     char* LZ4_slideInputBufferHC (void* LZ4HC_Data);
+LZ4_DEPRECATED("use LZ4_freeStreamHC() instead")   int   LZ4_freeHC (void* LZ4HC_Data);
+LZ4_DEPRECATED("use LZ4_compressHC_safe_continue() instead") int   LZ4_compressHC2_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_compressHC_safe_continue() instead") int   LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
+LZ4_DEPRECATED("use LZ4_createStreamHC() instead") int   LZ4_sizeofStreamStateHC(void);
+LZ4_DEPRECATED("use LZ4_resetStreamHC() instead")  int   LZ4_resetStreamStateHC(void* state, const char* inputBuffer);
 
 
 #if defined (__cplusplus)


### PR DESCRIPTION
Trivial fix. Since `DEPRECATED` is too generic name to public header, this PR replace the following macros:

 - `_DEPRECATE_WARNING_DEFBLOCK` to `LZ4_DEPRECATE_WARNING_DEFBLOCK`
 - `DEPRECATED` to `LZ4_DEPRECATED`