### PR TITLE
Fixed compiler warning when compiling for 64bit (iOS platform)

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -306,7 +306,7 @@ static unsigned LZ4_NbCommonBytes (register size_t val)
             _BitScanReverse( &r, (unsigned long)val );
             return (unsigned)(r>>3);
 #       elif defined(__GNUC__) && (GCC_VERSION >= 304) && !defined(LZ4_FORCE_SW_BITCOUNT)
-            return (__builtin_clz(val) >> 3);
+            return (__builtin_clzl(val) >> 3);
 #       else
             unsigned r;
             if (!(val>>16)) { r=2; val>>=8; } else { r=0; val>>=24; }


### PR DESCRIPTION
When compiling lz4 for a 64-bit iOS target, I got the compiler warning: `implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int'`. This commit fixes that warning.