### PR TITLE
Origin/r129/multiple inputs patch

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -265,7 +265,8 @@ int main(int argc, char** argv)
         forceStdout=0,
         forceCompress=0,
         main_pause=0,
-        multiple_inputs=0;
+        multiple_inputs=0,
+        multiple_rv=0;
     const char* input_filename=0;
     const char* output_filename=0;
     char* dynNameSpace=0;
@@ -518,7 +519,7 @@ int main(int argc, char** argv)
     if (decode)
     {
       if (multiple_inputs)
-        LZ4IO_decompressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION);
+        multiple_rv = LZ4IO_decompressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION);
       else
         DEFAULT_DECOMPRESSOR(input_filename, output_filename);
     }
@@ -533,7 +534,7 @@ int main(int argc, char** argv)
       else
       {
         if (multiple_inputs)
-          LZ4IO_compressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION, cLevel);
+          multiple_rv = LZ4IO_compressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION, cLevel);
         else
           DEFAULT_COMPRESSOR(input_filename, output_filename, cLevel);
       }
@@ -542,5 +543,6 @@ int main(int argc, char** argv)
     if (main_pause) waitEnter();
     free(dynNameSpace);
     free((void*)inFileNames);
+    if (multiple_rv != 0) return multiple_rv;
     return 0;
 }

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -515,22 +515,28 @@ int main(int argc, char** argv)
 
     /* IO Stream/File */
     LZ4IO_setNotificationLevel(displayLevel);
-    if (decode) DEFAULT_DECOMPRESSOR(input_filename, output_filename);
+    if (decode)
+    {
+      if (multiple_inputs)
+        LZ4IO_decompressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION);
+      else
+        DEFAULT_DECOMPRESSOR(input_filename, output_filename);
+    }
     else
     {
-        /* compression is default action */
-        if (legacy_format)
-        {
-            DISPLAYLEVEL(3, "! Generating compressed LZ4 using Legacy format (deprecated) ! \n");
-            LZ4IO_compressFilename_Legacy(input_filename, output_filename, cLevel);
-        }
+      /* compression is default action */
+      if (legacy_format)
+      {
+        DISPLAYLEVEL(3, "! Generating compressed LZ4 using Legacy format (deprecated) ! \n");
+        LZ4IO_compressFilename_Legacy(input_filename, output_filename, cLevel);
+      }
+      else
+      {
+        if (multiple_inputs)
+          LZ4IO_compressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION, cLevel);
         else
-        {
-            if (multiple_inputs)
-                LZ4IO_compressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION, cLevel);
-            else
-                DEFAULT_COMPRESSOR(input_filename, output_filename, cLevel);
-        }
+          DEFAULT_COMPRESSOR(input_filename, output_filename, cLevel);
+      }
     }
 
     if (main_pause) waitEnter();

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -51,8 +51,9 @@ static char const nulmark[] = "/dev/null";
 int LZ4IO_compressFilename  (const char* input_filename, const char* output_filename, int compressionlevel);
 int LZ4IO_decompressFilename(const char* input_filename, const char* output_filename);
 
-int LZ4IO_compressMultipleFilenames(const char** inFileNamesTable, int ifntSize, const char* suffix, int compressionlevel);
 
+int LZ4IO_compressMultipleFilenames(const char** inFileNamesTable, int ifntSize, const char* suffix, int compressionlevel);
+int LZ4IO_decompressMultipleFilenames(const char** inFileNamesTable, int ifntSize, const char* suffix);
 
 /* ************************************************** */
 /* ****************** Parameters ******************** */


### PR DESCRIPTION
Hello,

Pardon my mix-up if I've made this PR backward or something silly.  I'm not an expert in C either so please forgive oddities.

Google code issue 151 resulted in the addition of the -m switch which allows the lz4 cli compressor to act like others (gzip/bzip2/xz).  However, it does not work when decompressing with -d.  I made a sub-branch of an r129 branch to create a function which will perform the decompression of multiple files (in short:  ./lz4 -m -d file1.lz4 file2.lz4 now works).  This is the first commit.

The second change was to support missing input files.  When a compressor (gzip et al) encounters a missing input file specified on command line it simply prints a warning to STDERR and continues operating on the remaining files.  My second commit accomplishes this by attempting an fopen() on each input file when -m is specified.  This leaves other file opening/reading/writing errors to the actual compression function (which is fatal, and probably should be).  fopen() may not be ideal, but it's what I knew.  Oh, and missing_files is now tracked and will change the return code to '1' when missing inputs are discovered, which also mimics other compressors' default behavior.

If you need me to repackage these as different branches or whatever just let me know.  Or if you want you can just rip the three files out and make commits on your account; I'm not really concerned with credit or whatever.

Thanks!
Kyle