### PR TITLE
Add more descriptive frame errors

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -854,16 +854,16 @@ static size_t LZ4F_decodeHeader(LZ4F_dctx_internal_t* dctxPtr, const void* srcVo
     blockSizeID = (BD>>4) & _3BITS;
 
     /* validate */
-    if (version != 1) return (size_t)-ERROR_GENERIC;           /* Version Number, only supported value */
-    if (blockChecksumFlag != 0) return (size_t)-ERROR_GENERIC; /* Only supported value for the time being */
-    if (((FLG>>0)&_2BITS) != 0) return (size_t)-ERROR_GENERIC; /* Reserved bits */
-    if (((BD>>7)&_1BIT) != 0) return (size_t)-ERROR_GENERIC;   /* Reserved bit */
-    if (blockSizeID < 4) return (size_t)-ERROR_GENERIC;        /* 4-7 only supported values for the time being */
-    if (((BD>>0)&_4BITS) != 0) return (size_t)-ERROR_GENERIC;  /* Reserved bits */
+    if (version != 1) return (size_t)-ERROR_version_wrong;           /* Version Number, only supported value */
+    if (blockChecksumFlag != 0) return (size_t)-ERROR_unsupported_checksum; /* Only supported value for the time being */
+    if (((FLG>>0)&_2BITS) != 0) return (size_t)-ERROR_reserved_flag_set; /* Reserved bits */
+    if (((BD>>7)&_1BIT) != 0) return (size_t)-ERROR_reserved_flag_set;   /* Reserved bit */
+    if (blockSizeID < 4) return (size_t)-ERROR_unsupported_block_size;        /* 4-7 only supported values for the time being */
+    if (((BD>>0)&_4BITS) != 0) return (size_t)-ERROR_reserved_flag_set;  /* Reserved bits */
 
     /* check */
     HC = LZ4F_headerChecksum(srcPtr+4, frameHeaderSize-5);
-    if (HC != srcPtr[frameHeaderSize-1]) return (size_t)-ERROR_GENERIC;   /* Bad header checksum error */
+    if (HC != srcPtr[frameHeaderSize-1]) return (size_t)-ERROR_header_checksum_invalid;   /* Bad header checksum error */
 
     /* save */
     dctxPtr->frameInfo.blockMode = (blockMode_t)blockMode;

--- a/lib/lz4frame_static.h
+++ b/lib/lz4frame_static.h
@@ -57,6 +57,11 @@ extern "C" {
         ITEM(ERROR_wrongSrcPtr) \
         ITEM(ERROR_decompressionFailed) \
         ITEM(ERROR_checksum_invalid) \
+        ITEM(ERROR_version_wrong) \
+        ITEM(ERROR_unsupported_checksum) \
+        ITEM(ERROR_reserved_flag_set) \
+        ITEM(ERROR_unsupported_block_size) \
+        ITEM(ERROR_header_checksum_invalid) \
         ITEM(ERROR_maxCode)
 
 #define LZ4F_GENERATE_ENUM(ENUM) ENUM,


### PR DESCRIPTION
I was working on validating a different library's results and found this patch very helpful in pinpointing problems. Especially since not all implementations of lz4 support all features of lz4 frames.

Re-do of https://github.com/Cyan4973/lz4/pull/88 to hopefully go to the correct branch.