### PR TITLE
Fix LZ4_DEPRECATED() for old compilers

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -94,8 +94,8 @@
 #  endif   /* __STDC_VERSION__ */
 #endif  /* _MSC_VER */
 
-/* GCC_VERSION is defined into lz4.h */
-#if (GCC_VERSION >= 302) || (__INTEL_COMPILER >= 800) || defined(__clang__)
+/* LZ4_GCC_VERSION is defined into lz4.h */
+#if (LZ4_GCC_VERSION >= 302) || (__INTEL_COMPILER >= 800) || defined(__clang__)
 #  define expect(expr,value)    (__builtin_expect ((expr),(value)) )
 #else
 #  define expect(expr,value)    (expr)
@@ -261,7 +261,7 @@ static unsigned LZ4_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanForward64( &r, (U64)val );
             return (int)(r>>3);
-#       elif (defined(__clang__) || (GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#       elif (defined(__clang__) || (LZ4_GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (__builtin_ctzll((U64)val) >> 3);
 #       else
             static const int DeBruijnBytePos[64] = { 0, 0, 0, 0, 0, 1, 1, 2, 0, 3, 1, 3, 1, 4, 2, 7, 0, 2, 3, 6, 1, 5, 3, 5, 1, 3, 4, 4, 2, 5, 6, 7, 7, 0, 1, 2, 3, 3, 4, 6, 2, 6, 5, 5, 3, 4, 5, 6, 7, 1, 2, 4, 6, 4, 4, 5, 7, 2, 6, 5, 7, 6, 7, 7 };
@@ -274,7 +274,7 @@ static unsigned LZ4_NbCommonBytes (register size_t val)
             unsigned long r;
             _BitScanForward( &r, (U32)val );
             return (int)(r>>3);
-#       elif (defined(__clang__) || (GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#       elif (defined(__clang__) || (LZ4_GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (__builtin_ctz((U32)val) >> 3);
 #       else
             static const int DeBruijnBytePos[32] = { 0, 0, 3, 0, 3, 1, 3, 0, 3, 2, 2, 1, 3, 2, 0, 1, 3, 3, 1, 2, 2, 2, 2, 0, 3, 1, 2, 0, 1, 0, 1, 1 };
@@ -290,7 +290,7 @@ static unsigned LZ4_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse64( &r, val );
             return (unsigned)(r>>3);
-#       elif (defined(__clang__) || (GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#       elif (defined(__clang__) || (LZ4_GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (__builtin_clzll((U64)val) >> 3);
 #       else
             unsigned r;
@@ -306,7 +306,7 @@ static unsigned LZ4_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse( &r, (unsigned long)val );
             return (unsigned)(r>>3);
-#       elif (defined(__clang__) || (GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#       elif (defined(__clang__) || (LZ4_GCC_VERSION >= 304)) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (__builtin_clz((U32)val) >> 3);
 #       else
             unsigned r;

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -297,7 +297,7 @@ int LZ4_decompress_fast_usingDict (const char* source, char* dest, int originalS
 #    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
 #  else
 #    pragma message("WARNING: You need to implement LZ4_DEPRECATED for this compiler")
-#    define LZ4_DEPRECATED
+#    define LZ4_DEPRECATED(message)
 #  endif
 #endif // LZ4_DEPRECATE_WARNING_DEFBLOCK
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -288,10 +288,10 @@ int LZ4_decompress_fast_usingDict (const char* source, char* dest, int originalS
    You can also define LZ4_DEPRECATE_WARNING_DEFBLOCK. */
 #ifndef LZ4_DEPRECATE_WARNING_DEFBLOCK
 #  define LZ4_DEPRECATE_WARNING_DEFBLOCK
-#  define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
-#  if (GCC_VERSION >= 405) || defined(__clang__)
+#  define LZ4_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#  if (LZ4_GCC_VERSION >= 405) || defined(__clang__)
 #    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
-#  elif (GCC_VERSION >= 301)
+#  elif (LZ4_GCC_VERSION >= 301)
 #    define LZ4_DEPRECATED(message) __attribute__((deprecated))
 #  elif defined(_MSC_VER)
 #    define LZ4_DEPRECATED(message) __declspec(deprecated(message))

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -145,10 +145,10 @@ using LZ4_saveDictHC().
    You can also define LZ4_DEPRECATE_WARNING_DEFBLOCK. */
 #ifndef LZ4_DEPRECATE_WARNING_DEFBLOCK
 #  define LZ4_DEPRECATE_WARNING_DEFBLOCK
-#  define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
-#  if (GCC_VERSION >= 405) || defined(__clang__)
+#  define LZ4_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#  if (LZ4_GCC_VERSION >= 405) || defined(__clang__)
 #    define LZ4_DEPRECATED(message) __attribute__((deprecated(message)))
-#  elif (GCC_VERSION >= 301)
+#  elif (LZ4_GCC_VERSION >= 301)
 #    define LZ4_DEPRECATED(message) __attribute__((deprecated))
 #  elif defined(_MSC_VER)
 #    define LZ4_DEPRECATED(message) __declspec(deprecated(message))


### PR DESCRIPTION
This trivial PR fixes the following issues

 - Replace `GCC_VERSION` macro in public header with `LZ4_GCC_VERSION`
    - Since `GCC_VERSION` is common name, its name collision probability is quite high.
 - Fix `LZ4_DEPRECATED` macro for old/non-gcc/clang/MSVC compilers
    - Add placeholder argument
