### PR TITLE
cmake support for AIX, HPUX, Solaris and Windows

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -17,8 +17,10 @@ ENDIF()
 option(BUILD_TOOLS "Build the command line tools" ON)
 option(BUILD_LIBS  "Build the libraries in addition to the tools" ON)
 
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 if(UNIX AND BUILD_LIBS)
     add_definitions(-fPIC)
+endif()
 endif()
 
 set(LZ4_DIR ../lib/)
@@ -62,7 +64,12 @@ endif()
 
 #warnings
 
+if(MSVC)
+ADD_DEFINITIONS("-W4")
+endif()
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 ADD_DEFINITIONS("-Wall")
+endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
 ADD_DEFINITIONS("-Wextra")
 ADD_DEFINITIONS("-Wundef")
@@ -70,7 +77,10 @@ ADD_DEFINITIONS("-Wshadow")
 ADD_DEFINITIONS("-Wcast-align")
 ADD_DEFINITIONS("-Wstrict-prototypes")
 endif(CMAKE_COMPILER_IS_GNUCXX)
+if((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND
+   (NOT CMAKE_SYSTEM_NAME MATCHES "SunOS"))
 ADD_DEFINITIONS("-std=c99")
+endif()
 ADD_DEFINITIONS("-DLZ4_VERSION=\"${CPACK_PACKAGE_VERSION_PATCH}\"")
 INCLUDE_DIRECTORIES (${LZ4_DIR})
 


### PR DESCRIPTION
The following changes allow for builds on AIX and HPUX
with the native (non-gcc) compilers, as well as
Visual Studio 2008 and Visual Studio 2012.

Also work around a build error with gcc on Solaris
which fails due to the system detecting an attempt
to use C99 mode with an XPG mode less than XPG6.