### PR TITLE
Install the lz4frame.h header in the cmake build

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 set(LZ4_DIR ../lib/)
 set(PRG_DIR ../programs/)
-set(LZ4_SRCS_LIB ${LZ4_DIR}lz4.c ${LZ4_DIR}lz4hc.c ${LZ4_DIR}lz4.h ${LZ4_DIR}lz4hc.h ${LZ4_DIR}lz4frame.c ${LZ4_DIR}xxhash.c)
+set(LZ4_SRCS_LIB ${LZ4_DIR}lz4.c ${LZ4_DIR}lz4hc.c ${LZ4_DIR}lz4.h ${LZ4_DIR}lz4hc.h ${LZ4_DIR}lz4frame.c ${LZ4_DIR}lz4frame.h ${LZ4_DIR}xxhash.c)
 set(LZ4_SRCS ${LZ4_DIR}lz4frame.c ${LZ4_DIR}xxhash.c ${PRG_DIR}bench.c ${PRG_DIR}lz4cli.c ${PRG_DIR}lz4io.c)
 
 if(BUILD_TOOLS AND NOT BUILD_LIBS)
@@ -53,6 +53,7 @@ if(BUILD_LIBS)
     install(FILES
     ${LZ4_DIR}/lz4.h
     ${LZ4_DIR}/lz4hc.h
+    ${LZ4_DIR}/lz4frame.h
     DESTINATION include
     )
     


### PR DESCRIPTION
I believe the intention here was to also install lz4frame.h in the cmake file similarly to the Makefile-based build.