### PR TITLE
Remove blank page from manual.

### DIFF
--- a/programs/lz4.1
+++ b/programs/lz4.1
@@ -1,13 +1,13 @@
-\"
-\" lz4.1: This is a manual page for 'lz4' program. This file is part of the
-\" lz4 <https://code.google.com/p/lz4/> project.
-\" Author: Yann Collet
-\"
-
-\" No hyphenation
+.\"
+.\" lz4.1: This is a manual page for 'lz4' program. This file is part of the
+.\" lz4 <https://code.google.com/p/lz4/> project.
+.\" Author: Yann Collet
+.\"
+.
+.\" No hyphenation
 .hy 0
 .nr HY 0
-
+.
 .TH lz4 "1" "2015-03-21" "lz4" "User Commands"
 .SH NAME
 \fBlz4, unlz4, lz4cat\fR \- Compress or decompress .lz4 files


### PR DESCRIPTION
The manual page for lz4, unlz4, lz4cat programs had 8 empty lines before the `.TH` request which made the output start with a blank page (or just with empty lines when typesetting for terminal).