### PR TITLE
Improve lz4 command line error message when dealing with console IO

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((c-mode . ((tab-width . 2))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((c-mode . ((tab-width . 2))))

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -542,7 +542,7 @@ int main(int argc, char** argv)
     /* Check if output is defined as console; trigger an error in this case */
     if (!strcmp(output_filename,stdoutmark) && IS_CONSOLE(stdout) && !forceStdout)
     {
-        DISPLAYLEVEL(1, "refusing to output to console\n");
+        DISPLAYLEVEL(1, "refusing to write to console without -c\n");
         exit(1);
     }
 

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -490,7 +490,11 @@ int main(int argc, char** argv)
     if(!input_filename) { input_filename=stdinmark; }
 
     /* Check if input is defined as console; trigger an error in this case */
-    if (!strcmp(input_filename, stdinmark) && IS_CONSOLE(stdin) ) badusage();
+    if (!strcmp(input_filename, stdinmark) && IS_CONSOLE(stdin) )
+    {
+        DISPLAYLEVEL(1, "refusing to read from a console\n");
+        exit(1);
+    }
 
     /* Check if benchmark is selected */
     if (bench)
@@ -536,7 +540,11 @@ int main(int argc, char** argv)
     }
 
     /* Check if output is defined as console; trigger an error in this case */
-    if (!strcmp(output_filename,stdoutmark) && IS_CONSOLE(stdout) && !forceStdout) badusage();
+    if (!strcmp(output_filename,stdoutmark) && IS_CONSOLE(stdout) && !forceStdout)
+    {
+        DISPLAYLEVEL(1, "refusing to output to console\n");
+        exit(1);
+    }
 
     /* Downgrade notification level in pure pipe mode (stdin + stdout) and multiple file mode */
     if (!strcmp(input_filename, stdinmark) && !strcmp(output_filename,stdoutmark) && (displayLevel==2)) displayLevel=1;


### PR DESCRIPTION
I must have spent ten minutes trying to get the "lz4" tool to work before realizing that "Incorrect parameters" meant "you're writing to a pty".