### PR TITLE
Fix bug where minimally sized frame headers are not decoded

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1080,7 +1080,7 @@ size_t LZ4F_decompress(LZ4F_decompressionContext_t decompressionContext,
 
         case dstage_getHeader:
             {
-                if ((size_t)(srcEnd-srcPtr) >= maxFHSize)   /* enough to decode - shortcut */
+                if ((size_t)(srcEnd-srcPtr) >= minFHSize)   /* enough to decode - shortcut */
                 {
                     LZ4F_errorCode_t errorCode = LZ4F_decodeHeader(dctxPtr, srcPtr, srcEnd-srcPtr);
                     if (LZ4F_isError(errorCode)) return errorCode;


### PR DESCRIPTION
I believe this is the first step toward solving issue #157.

The remaining issue is actually more subtle and may not actually be incorrect behaviour. `LZ4F_getFrameInfo()` called on an empty frame will return `-LZ4F_ERROR_frameHeader_incomplete` when the decode stage is `<= dstage_storageHeader`. If an empty frame is encountered, `LZ4F_decompress()` will simply consume `srcBuffer` without writing anything to `dstBuffer`. Should `LZ4F_getFrameInfo()` return the *most recent* frame info? That's how I read the documentation, but it could just need clarification.