### PR TITLE
Adding unaligned access support for aarch64

### DIFF
--- a/lib/xxhash.c
+++ b/lib/xxhash.c
@@ -40,7 +40,8 @@ You can contact the author at :
  * If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
  * You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
  */
-#if defined(__ARM_FEATURE_UNALIGNED) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#if defined(__ARM_FEATURE_UNALIGNED) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64) \
+    || defined(__aarch64__)
 #  define XXH_USE_UNALIGNED_ACCESS 1
 #endif
 


### PR DESCRIPTION
For ARMv8 processors, unaligned access has been supported. The "__ARM_FEATURE_UNALIGNED" is only turned on for 32bit ARM gcc for armv7-a processors. Thus __aarch64__ is needed to turn on the XXH_USE_UNALIGNED_ACCESS option.