### PR TITLE
Fix build error on MinGW

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -66,7 +66,7 @@
 #  include <io.h>      /* _setmode, _fileno, _get_osfhandle */
 #  if !defined(__DJGPP__)
 #    define SET_BINARY_MODE(file) { int unused=_setmode(_fileno(file), _O_BINARY); (void)unused; }
-#    include <Windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
+#    include <windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
 #    define SET_SPARSE_FILE_MODE(file) { DWORD dw; DeviceIoControl((HANDLE) _get_osfhandle(_fileno(file)), FSCTL_SET_SPARSE, 0, 0, 0, 0, &dw, 0); }
 #    if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Avoid MSVC fseek()'s 2GiB barrier */
 #      define fseek _fseeki64


### PR DESCRIPTION
Header file name is case insensitive on Windows but it is case sensitive
on Linux. "Windows.h" can't be found on Linux.