### PR TITLE
New SONAME / code reuse

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -50,13 +50,13 @@ INCLUDEDIR=$(PREFIX)/include
 # see : https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html
 ifeq ($(shell uname), Darwin)
 	SHARED_EXT = dylib
-	SHARED_EXT_MAJOR = $(LIBVER_MAJOR).$(SHARED_EXT)
+	SHARED_EXT_MAJOR = $(LIBVER_MAJOR).$(LIBVER_MINOR).$(SHARED_EXT)
 	SHARED_EXT_VER = $(LIBVER).$(SHARED_EXT)
-	SONAME_FLAGS = -install_name $(PREFIX)/lib/liblz4.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR) -current_version $(LIBVER)
+	SONAME_FLAGS = -install_name $(PREFIX)/lib/liblz4.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR).$(LIBVER_MINOR) -current_version $(LIBVER)
 else
-	SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR)
+	SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR).$(LIBVER_MINOR)
 	SHARED_EXT = so
-	SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR)
+	SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR).$(LIBVER_MINOR)
 	SHARED_EXT_VER = $(SHARED_EXT).$(LIBVER)
 endif
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -39,7 +39,7 @@ RELEASE?= r131
 DESTDIR?=
 PREFIX ?= /usr/local
 CFLAGS ?= -O3
-CFLAGS += -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -pedantic -DLZ4_VERSION=\"$(RELEASE)\"
+CFLAGS += -DXXH_NAMESPACE=LZ4_ -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -pedantic -DLZ4_VERSION=\"$(RELEASE)\"
 FLAGS  := -I../lib $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 BINDIR := $(PREFIX)/bin
@@ -72,32 +72,32 @@ bins: lz4 lz4c fullbench fuzzer frametest datagen
 
 all: bins m32
 
-lz4: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/xxhash.c bench.c lz4io.c lz4cli.c
-	$(CC)      $(FLAGS) $^ -o $@$(EXT)
+lz4: bench.c lz4io.c lz4cli.c
+	$(CC)      $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-lz4c  : $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/xxhash.c bench.c lz4io.c lz4cli.c
-	$(CC)      $(FLAGS) -DENABLE_LZ4C_LEGACY_OPTIONS $^ -o $@$(EXT)
+lz4c: bench.c lz4io.c lz4cli.c
+	$(CC)      $(FLAGS) -DENABLE_LZ4C_LEGACY_OPTIONS $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-lz4c32: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/xxhash.c bench.c lz4io.c lz4cli.c
-	$(CC) -m32 $(FLAGS) -DENABLE_LZ4C_LEGACY_OPTIONS $^ -o $@$(EXT)
+lz4c32: bench.c lz4io.c lz4cli.c
+	$(CC) -m32 $(FLAGS) -DENABLE_LZ4C_LEGACY_OPTIONS $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-fullbench  : $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/xxhash.c fullbench.c
-	$(CC)      $(FLAGS) $^ -o $@$(EXT)
+fullbench: fullbench.c
+	$(CC)      $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-fullbench32: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/xxhash.c fullbench.c
-	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT)
+fullbench32: fullbench.c
+	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-fuzzer  : $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c fuzzer.c
-	$(CC)      $(FLAGS) $^ -o $@$(EXT)
+fuzzer: fuzzer.c
+	$(CC)      $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-fuzzer32: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c fuzzer.c
-	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT)
+fuzzer32: fuzzer.c
+	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-frametest: $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c frametest.c
-	$(CC)      $(FLAGS) $^ -o $@$(EXT)
+frametest: frametest.c
+	$(CC)      $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
-frametest32: $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c frametest.c
-	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT)
+frametest32: frametest.c
+	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT) -L${LZ4DIR} -llz4
 
 datagen : datagen.c datagencli.c
 	$(CC)      $(FLAGS) $^ -o $@$(EXT)


### PR DESCRIPTION
1. Is something I had to do for a Linux distribution. It must not happen that different ABI sets use the same SONAME and I chose "1.7" as a new identifier.
2. Maximum code reuse seems like a beneficial goal.