### PR TITLE
Updating incorrect hyperlink to lz4 frame format

### DIFF
--- a/lz4_Block_format.md
+++ b/lz4_Block_format.md
@@ -19,7 +19,7 @@ not how the compressor nor decompressor actually work.
 The correctness of the decompressor should not depend
 on implementation details of the compressor, and vice versa.
 
-[LZ4 Frame format]: LZ4_Frame_format.md
+[LZ4 Frame format]: lz4_Frame_format.md 
 
 
 


### PR DESCRIPTION
Just a rename. Incorrect file name here gives 404 error. 