### PR TITLE
Clean up links, repository-wide

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,7 +19,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # You can contact the author at :
-#  - LZ4 source repository : http://code.google.com/p/lz4/
+#  - LZ4 source repository : https://github.com/Cyan4973/lz4
 #  - LZ4 forum froup : https://groups.google.com/forum/#!forum/lz4c
 # ##########################################################################
 # This makefile compile and test

--- a/lib/liblz4.pc.in
+++ b/lib/liblz4.pc.in
@@ -8,7 +8,7 @@ includedir=@INCLUDEDIR@
 
 Name: lz4
 Description: fast lossless compression algorithm library
-URL: http://lz4.org/
+URL: http://www.lz4.org/
 Version: @VERSION@
 Libs: -L@LIBDIR@ -llz4
 Cflags: -I@INCLUDEDIR@

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -63,7 +63,7 @@
  * Method 2 : direct access. This method is portable but violate C standard.
  *            It can generate buggy code on targets which generate assembly depending on alignment.
  *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
- * See http://fastcompression.blogspot.fr/2015/08/accessing-unaligned-memory.html for details.
+ * See https://fastcompression.blogspot.fr/2015/08/accessing-unaligned-memory.html for details.
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */

--- a/lib/xxhash.c
+++ b/lib/xxhash.c
@@ -46,7 +46,7 @@
  * Method 2 : direct access. This method doesn't depend on compiler but violate C standard.
  *            It can generate buggy code on targets which do not support unaligned memory accesses.
  *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
- * See http://stackoverflow.com/a/32095106/646947 for details.
+ * See https://stackoverflow.com/a/32095106/646947 for details.
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
@@ -167,7 +167,7 @@ static U64 XXH_read64(const void* ptr) { return ((const unalign*)ptr)->u64; }
 #else
 
 /* portable and safe solution. Generally efficient.
- * see : http://stackoverflow.com/a/32095106/646947
+ * see : https://stackoverflow.com/a/32095106/646947
  */
 
 static U32 XXH_read32(const void* memPtr)

--- a/versionsTest/test-lz4-versions.py
+++ b/versionsTest/test-lz4-versions.py
@@ -38,7 +38,7 @@ def get_git_tags():
     tags = stdout.decode('utf-8').split()
     return tags
 
-# http://stackoverflow.com/a/19711609/2132223
+# https://stackoverflow.com/a/19711609/2132223
 def sha1_of_file(filepath):
     with open(filepath, 'rb') as f:
         return hashlib.sha1(f.read()).hexdigest()


### PR DESCRIPTION
I noticed that a few `http://...` links could be replaced by `https://...` links, which are usually deemed "safer".  Also, the self-reference is broken, as it still points to a googlecode repository.  This raises a few warnings when used downs stream ([example](https://github.com/tgingold/ghdl/pull/117)).