### PR TITLE
Fix build error with MinGW on Linux

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -66,7 +66,7 @@
 #  include <io.h>      /* _setmode, _fileno, _get_osfhandle */
 #  if !defined(__DJGPP__)
 #    define SET_BINARY_MODE(file) { int unused=_setmode(_fileno(file), _O_BINARY); (void)unused; }
-#    include <Windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
+#    include <windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
 #    define SET_SPARSE_FILE_MODE(file) { DWORD dw; DeviceIoControl((HANDLE) _get_osfhandle(_fileno(file)), FSCTL_SET_SPARSE, 0, 0, 0, 0, &dw, 0); }
 #    if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Avoid MSVC fseek()'s 2GiB barrier */
 #      define fseek _fseeki64


### PR DESCRIPTION
Linux uses case sensitive file system. So "Windows.h" doesn't exist.

    % make CC=x86_64-w64-mingw32-gcc EXT=.exe SHARD_EXT=dll
    ...
    lz4io.c:69:73: fatal error: Windows.h: No such file or directory
    compilation terminated.
    ...