### PR TITLE
Fix POSIX portability and cmake file

### DIFF
--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -92,21 +92,23 @@ endif()
 #warnings
 
 if(MSVC)
-ADD_DEFINITIONS("-W4")
+    ADD_DEFINITIONS("-W4")
 endif()
 if(GNU_COMPATIBLE_COMPILER)
-ADD_DEFINITIONS("-Wall")
+    ADD_DEFINITIONS("-Wall")
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
-ADD_DEFINITIONS("-Wextra")
-ADD_DEFINITIONS("-Wundef")
-ADD_DEFINITIONS("-Wshadow")
-ADD_DEFINITIONS("-Wcast-align")
-ADD_DEFINITIONS("-Wstrict-prototypes")
+    ADD_DEFINITIONS("-Wextra")
+    ADD_DEFINITIONS("-Wundef")
+    ADD_DEFINITIONS("-Wshadow")
+    ADD_DEFINITIONS("-Wcast-align")
+    ADD_DEFINITIONS("-Wstrict-prototypes")
 endif(CMAKE_COMPILER_IS_GNUCXX)
-if(GNU_COMPATIBLE_COMPILER AND
-   (NOT CMAKE_SYSTEM_NAME MATCHES "SunOS"))
-ADD_DEFINITIONS("-std=c99")
+if(GNU_COMPATIBLE_COMPILER)
+    # we need gnu99 instead of c99 on Linux and Solaris
+    # to get C99 and POSIX definitions
+    # an alternative with cmake >= 3.1/3.2 is the C_STANDARD property
+    ADD_DEFINITIONS("-std=gnu99")
 endif()
 ADD_DEFINITIONS("-DLZ4_VERSION=\"${CPACK_PACKAGE_VERSION_PATCH}\"")
 INCLUDE_DIRECTORIES (${LZ4_DIR})

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -16,6 +16,7 @@ ENDIF()
 
 option(BUILD_TOOLS "Build the command line tools" ON)
 option(BUILD_LIBS  "Build the libraries in addition to the tools" ON)
+option(LINK_TOOLS_WITH_LIB "Link the command line tools with the (shared) library" OFF)
 
 IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
    "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
@@ -28,7 +29,7 @@ set(PRG_DIR ../programs/)
 set(LZ4_SRCS_LIB ${LZ4_DIR}lz4.c ${LZ4_DIR}lz4hc.c ${LZ4_DIR}lz4.h ${LZ4_DIR}lz4hc.h ${LZ4_DIR}lz4frame.c ${LZ4_DIR}lz4frame.h ${LZ4_DIR}xxhash.c)
 set(LZ4_SRCS ${LZ4_DIR}lz4frame.c ${LZ4_DIR}xxhash.c ${PRG_DIR}bench.c ${PRG_DIR}lz4cli.c ${PRG_DIR}lz4io.c)
 
-if(BUILD_TOOLS AND NOT BUILD_LIBS)
+if(BUILD_TOOLS AND NOT (LINK_TOOLS_WITH_LIB AND BUILD_LIBS))
     set(LZ4_SRCS ${LZ4_SRCS} ${LZ4_SRCS_LIB})
 endif()
 
@@ -41,15 +42,15 @@ if(BUILD_LIBS)
 
 
     SET(LIBS_TARGETS "")
-    IF(NOT WIN32)
+    IF(WIN32)
+        add_library(liblz4 STATIC ${LZ4_SRCS_LIB})
+        SET(LIBS_TARGETS liblz4)
+    ELSE(WIN32)
         add_library(liblz4 SHARED ${LZ4_SRCS_LIB})
         add_library(liblz4_static STATIC ${LZ4_SRCS_LIB})
         SET_TARGET_PROPERTIES(liblz4_static PROPERTIES OUTPUT_NAME lz4)
         SET(LIBS_TARGETS liblz4 liblz4_static)
-    ELSE(NOT WIN32)
-        add_library(liblz4 STATIC ${LZ4_SRCS_LIB})
-        SET(LIBS_TARGETS liblz4)
-    ENDIF(NOT WIN32)
+    ENDIF(WIN32)
 
     set_target_properties(liblz4 PROPERTIES
     OUTPUT_NAME lz4
@@ -78,7 +79,7 @@ if(BUILD_LIBS)
     DESTINATION "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig"
     )
 
-    if(BUILD_TOOLS)
+  if(BUILD_TOOLS AND LINK_TOOLS_WITH_LIB)
         target_link_libraries(lz4 liblz4)
     endif()
 endif()

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -22,11 +22,6 @@ IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
   SET(GNU_COMPATIBLE_COMPILER 1)
 ENDIF()
 
-if(GNU_COMPATIBLE_COMPILER)
-if(UNIX AND BUILD_LIBS)
-    add_definitions(-fPIC)
-endif()
-endif()
 
 set(LZ4_DIR ../lib/)
 set(PRG_DIR ../programs/)
@@ -45,15 +40,15 @@ endif()
 if(BUILD_LIBS)
 
 
-	SET(LIBS_TARGETS "")
-	IF(NOT WIN32)
-	add_library(liblz4 SHARED ${LZ4_SRCS_LIB})
-    add_library(liblz4_static STATIC ${LZ4_SRCS_LIB})
-    SET_TARGET_PROPERTIES(liblz4_static PROPERTIES OUTPUT_NAME lz4)
-	SET(LIBS_TARGETS liblz4 liblz4_static)
-	ELSE(NOT WIN32)
-	add_library(liblz4 STATIC ${LZ4_SRCS_LIB})
-	SET(LIBS_TARGETS liblz4)
+    SET(LIBS_TARGETS "")
+    IF(NOT WIN32)
+        add_library(liblz4 SHARED ${LZ4_SRCS_LIB})
+        add_library(liblz4_static STATIC ${LZ4_SRCS_LIB})
+        SET_TARGET_PROPERTIES(liblz4_static PROPERTIES OUTPUT_NAME lz4)
+        SET(LIBS_TARGETS liblz4 liblz4_static)
+    ELSE(NOT WIN32)
+        add_library(liblz4 STATIC ${LZ4_SRCS_LIB})
+        SET(LIBS_TARGETS liblz4)
     ENDIF(NOT WIN32)
 
     set_target_properties(liblz4 PROPERTIES

--- a/cmake_unofficial/CMakeLists.txt
+++ b/cmake_unofficial/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CPack)
 cmake_minimum_required (VERSION 2.6)
 INCLUDE (CheckTypeSize)
 check_type_size("void *" SIZEOF_VOID_P)
-IF( "${SIZEOF_VOID_P}" STREQUAL  "8" )
+IF(SIZEOF_VOID_P STREQUAL  "8")
     set (CMAKE_SYSTEM_PROCESSOR "64bit")
     MESSAGE( STATUS "64 bit architecture detected size of void * is " ${SIZEOF_VOID_P})
 ENDIF()
@@ -18,8 +18,8 @@ option(BUILD_TOOLS "Build the command line tools" ON)
 option(BUILD_LIBS  "Build the libraries in addition to the tools" ON)
 option(LINK_TOOLS_WITH_LIB "Link the command line tools with the (shared) library" OFF)
 
-IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
-   "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+IF(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
+   CMAKE_C_COMPILER_ID STREQUAL "Clang")
   SET(GNU_COMPATIBLE_COMPILER 1)
 ENDIF()
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,7 +28,7 @@
 # ##########################################################################
 
 CFLAGS ?= -O3
-CFLAGS += -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes
+CFLAGS += -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes
 FLAGS  := -I../lib $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 TESTFILE= Makefile

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -41,7 +41,7 @@ DESTDIR?=
 PREFIX ?= /usr/local
 CPPFLAGS= -DXXH_NAMESPACE=LZ4_
 CFLAGS ?= -O3
-CFLAGS += -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wcast-qual -Wstrict-prototypes -pedantic
+CFLAGS += -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wcast-qual -Wstrict-prototypes -pedantic
 FLAGS   = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 LIBDIR?= $(PREFIX)/lib

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -49,7 +49,8 @@
 #  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
 #endif
 
-#define _POSIX_SOURCE 1        /* for fileno() within <stdio.h> on unix */
+/* cf. http://man7.org/linux/man-pages/man7/feature_test_macros.7.html */
+#define _XOPEN_VERSION 600 /* POSIX.2001, for fileno() within <stdio.h> on unix */
 
 
 /****************************


### PR DESCRIPTION
Main changes:

- request POSIX.2001 definitions in a portable fashion
- fix compile on Solaris 10
- cmake build file fixes

cf. the commit messages for details