### PR TITLE
Use lower case for header file name

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -70,7 +70,7 @@
 #  if !defined(__DJGPP__)
 #    define SET_BINARY_MODE(file) { int unused=_setmode(_fileno(file), _O_BINARY); (void)unused; }
 #    include <windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
-#    include <WinIoCtl.h> /* FSCTL_SET_SPARSE */
+#    include <winioctl.h> /* FSCTL_SET_SPARSE */
 #    define SET_SPARSE_FILE_MODE(file) { DWORD dw; DeviceIoControl((HANDLE) _get_osfhandle(_fileno(file)), FSCTL_SET_SPARSE, 0, 0, 0, 0, &dw, 0); }
 #    if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Avoid MSVC fseek()'s 2GiB barrier */
 #      define fseek _fseeki64


### PR DESCRIPTION
"WinIoCtl.h" works on Windows because Windows uses case insensitive file
system. But it doesn't work on GNU/Linux (for cross compiling with
MinGW) because GNU/Linux uses case sensitive file system.